### PR TITLE
Fix unknown column updated_at in SQL query

### DIFF
--- a/README_fix_instructions.md
+++ b/README_fix_instructions.md
@@ -1,0 +1,82 @@
+# Fix for "Unknown column 'updated_at' in 'field list'" Error
+
+## Problem
+The error occurs because your SQL query is trying to update an `updated_at` column that doesn't exist in the `hm18_fee` table.
+
+## Error Details
+- **File**: `/home/kaewkase/domains/kaewkaset.com/public_html/hm18/dbcontroller.php:65`
+- **Error**: `SQL Prepare Error: Unknown column 'updated_at' in 'field list'`
+- **Table**: `hm18_fee`
+
+## Solutions
+
+### Solution 1: Add the missing column to the database (Recommended)
+
+Run this SQL command in your MySQL database:
+
+```sql
+ALTER TABLE hm18_fee ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+```
+
+### Solution 2: Remove the updated_at column from your query
+
+If you don't need the `updated_at` column, modify your query in `index.php`:
+
+**Before:**
+```sql
+UPDATE hm18_fee SET status = ?, updated_at = NOW() WHERE id = ?
+```
+
+**After:**
+```sql
+UPDATE hm18_fee SET status = ? WHERE id = ?
+```
+
+### Solution 3: Use the automated fix script
+
+1. Update the database credentials in `dbcontroller.php`
+2. Run the `check_and_fix.php` script:
+   ```bash
+   php check_and_fix.php
+   ```
+
+## Files Created
+
+1. **`dbcontroller.php`** - Database controller class with proper error handling
+2. **`index.php`** - Example showing the problematic query and solutions
+3. **`fix_database.sql`** - SQL script to add the missing column
+4. **`check_and_fix.php`** - Automated script to check and fix the database structure
+5. **`README_fix_instructions.md`** - This file with detailed instructions
+
+## Database Configuration
+
+Before running any scripts, update the database credentials in `dbcontroller.php`:
+
+```php
+private $host = "your_host";
+private $user = "your_username";
+private $password = "your_password";
+private $database = "your_database";
+```
+
+## Verification
+
+After applying the fix, you can verify the table structure:
+
+```sql
+DESCRIBE hm18_fee;
+```
+
+You should see the `updated_at` column in the output.
+
+## Common Issues
+
+1. **Permission denied**: Make sure your database user has ALTER privileges
+2. **Connection failed**: Check your database credentials
+3. **Table doesn't exist**: Verify the table name is correct
+
+## Additional Notes
+
+- The `updated_at` column will automatically update to the current timestamp whenever a row is modified
+- Consider adding a `created_at` column as well for better record keeping
+- Always backup your database before making schema changes

--- a/check_and_fix.php
+++ b/check_and_fix.php
@@ -1,0 +1,84 @@
+<?php
+require_once 'dbcontroller.php';
+
+class DatabaseFixer {
+    private $db;
+    
+    public function __construct($db) {
+        $this->db = $db;
+    }
+    
+    public function checkColumnExists($table, $column) {
+        $query = "SHOW COLUMNS FROM $table LIKE '$column'";
+        $result = $this->db->query($query);
+        return mysqli_num_rows($result) > 0;
+    }
+    
+    public function addUpdatedAtColumn($table) {
+        if (!$this->checkColumnExists($table, 'updated_at')) {
+            $query = "ALTER TABLE $table ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP";
+            $result = $this->db->query($query);
+            
+            if ($result) {
+                echo "✓ Successfully added 'updated_at' column to $table table\n";
+                return true;
+            } else {
+                echo "✗ Failed to add 'updated_at' column to $table table\n";
+                return false;
+            }
+        } else {
+            echo "✓ Column 'updated_at' already exists in $table table\n";
+            return true;
+        }
+    }
+    
+    public function showTableStructure($table) {
+        echo "\n=== Current structure of $table table ===\n";
+        $query = "DESCRIBE $table";
+        $result = $this->db->query($query);
+        
+        if ($result) {
+            while ($row = mysqli_fetch_assoc($result)) {
+                echo sprintf("%-15s %-15s %-10s %-10s %-10s %-10s\n", 
+                    $row['Field'], 
+                    $row['Type'], 
+                    $row['Null'], 
+                    $row['Key'], 
+                    $row['Default'], 
+                    $row['Extra']
+                );
+            }
+        }
+        echo "\n";
+    }
+}
+
+// Usage example
+try {
+    $db = new DBController();
+    $fixer = new DatabaseFixer($db);
+    
+    echo "=== Database Structure Check ===\n";
+    $fixer->showTableStructure('hm18_fee');
+    
+    echo "=== Fixing missing updated_at column ===\n";
+    $fixer->addUpdatedAtColumn('hm18_fee');
+    
+    echo "\n=== Updated table structure ===\n";
+    $fixer->showTableStructure('hm18_fee');
+    
+    echo "=== Testing the original query ===\n";
+    $query = "UPDATE hm18_fee SET status = ?, updated_at = NOW() WHERE id = ?";
+    $params = array('active', 1);
+    
+    try {
+        $result = $db->execute($query, $params);
+        echo "✓ Query executed successfully!\n";
+    } catch (Exception $e) {
+        echo "✗ Query still failed: " . $e->getMessage() . "\n";
+    }
+    
+} catch (Exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+}
+?>

--- a/dbcontroller.php
+++ b/dbcontroller.php
@@ -1,0 +1,59 @@
+<?php
+class DBController {
+    private $host = "localhost";
+    private $user = "your_username";
+    private $password = "your_password";
+    private $database = "your_database";
+    private $conn;
+
+    function __construct() {
+        $this->conn = $this->connectDB();
+    }
+
+    function connectDB() {
+        $conn = mysqli_connect($this->host, $this->user, $this->password, $this->database);
+        return $conn;
+    }
+
+    function execute($query, $params = array()) {
+        try {
+            // Prepare the statement
+            $stmt = $this->conn->prepare($query);
+            
+            if (!$stmt) {
+                throw new Exception("SQL Prepare Error: " . $this->conn->error);
+            }
+            
+            // Bind parameters if provided
+            if (!empty($params)) {
+                $types = str_repeat('s', count($params)); // Assuming all strings for now
+                $stmt->bind_param($types, ...$params);
+            }
+            
+            // Execute the statement
+            $result = $stmt->execute();
+            
+            if (!$result) {
+                throw new Exception("SQL Execute Error: " . $stmt->error);
+            }
+            
+            $stmt->close();
+            return $result;
+            
+        } catch (Exception $e) {
+            throw new Exception("SQL Prepare Error: " . $e->getMessage());
+        }
+    }
+
+    function query($query) {
+        $result = mysqli_query($this->conn, $query);
+        return $result;
+    }
+
+    function numRows($query) {
+        $result = mysqli_query($this->conn, $query);
+        $rowcount = mysqli_num_rows($result);
+        return $rowcount;
+    }
+}
+?>

--- a/fix_database.sql
+++ b/fix_database.sql
@@ -1,0 +1,20 @@
+-- Fix for the missing 'updated_at' column in hm18_fee table
+-- Run this script in your MySQL database
+
+-- First, let's check the current structure of the table
+DESCRIBE hm18_fee;
+
+-- Add the missing updated_at column
+ALTER TABLE hm18_fee ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;
+
+-- Verify the column was added
+DESCRIBE hm18_fee;
+
+-- Optional: If you want to add created_at column as well (common practice)
+-- ALTER TABLE hm18_fee ADD COLUMN created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP;
+
+-- Show the updated table structure
+SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT, EXTRA 
+FROM INFORMATION_SCHEMA.COLUMNS 
+WHERE TABLE_NAME = 'hm18_fee' 
+AND TABLE_SCHEMA = DATABASE();

--- a/index.php
+++ b/index.php
@@ -1,0 +1,33 @@
+<?php
+require_once 'dbcontroller.php';
+
+$db = new DBController();
+
+try {
+    // This is the problematic query that's causing the error
+    // The 'updated_at' column doesn't exist in the hm18_fee table
+    $query = "UPDATE hm18_fee SET status = ?, updated_at = NOW() WHERE id = ?";
+    $params = array('active', 1);
+    
+    // This will fail because 'updated_at' column doesn't exist
+    $result = $db->execute($query, $params);
+    
+} catch (Exception $e) {
+    echo "Error: " . $e->getMessage() . "\n";
+    
+    // Solution 1: Remove the updated_at column from the query
+    echo "\n=== Solution 1: Remove updated_at column ===\n";
+    try {
+        $fixed_query = "UPDATE hm18_fee SET status = ? WHERE id = ?";
+        $result = $db->execute($fixed_query, $params);
+        echo "Query executed successfully!\n";
+    } catch (Exception $e2) {
+        echo "Still error: " . $e2->getMessage() . "\n";
+    }
+    
+    // Solution 2: Add the updated_at column to the database
+    echo "\n=== Solution 2: Add updated_at column to database ===\n";
+    echo "Run this SQL command in your database:\n";
+    echo "ALTER TABLE hm18_fee ADD COLUMN updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP;\n";
+}
+?>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Provide files to fix the "Unknown column 'updated_at'" SQL error by adding the missing column or modifying queries.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The changes introduce new files (`dbcontroller.php`, `index.php`, `fix_database.sql`, `check_and_fix.php`, `README_fix_instructions.md`) to address a `SQL Prepare Error: Unknown column 'updated_at' in 'field list'`. Since the original user files were not accessible, these files demonstrate the problem and provide multiple solutions (adding the column via SQL or an automated script, or modifying the problematic query).

---

[Open in Web](https://cursor.com/agents?id=bc-4ccd5b33-1fe2-48f4-870a-046438613c0a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4ccd5b33-1fe2-48f4-870a-046438613c0a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)